### PR TITLE
ramips: missing pinctrl

### DIFF
--- a/target/linux/ramips/dts/mt7620a_tplink_archer-c5-v4.dts
+++ b/target/linux/ramips/dts/mt7620a_tplink_archer-c5-v4.dts
@@ -208,6 +208,10 @@
 &wmac {
 	nvmem-cells = <&macaddr_rom_f100>;
 	nvmem-cell-names = "mac-address";
+
+	pinctrl-names = "default", "pa_gpio";
+	pinctrl-0 = <&pa_pins>;
+	pinctrl-1 = <&pa_gpio_pins>;
 };
 
 &wifi {


### PR DESCRIPTION
Patch adds missing pinctl (support for external LNA)