### PR TITLE
ramips: remove bad cell count info

### DIFF
--- a/target/linux/ramips/dts/mt7620a_tplink_archer-c5-v4.dts
+++ b/target/linux/ramips/dts/mt7620a_tplink_archer-c5-v4.dts
@@ -69,6 +69,13 @@
 	};
 };
 
+&spi0 {
+	flash@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+	};
+};
+
 &gpio0 {
 	interrupt-controller;
 	#interrupt-cells = <2>;


### PR DESCRIPTION
Fix for:
[    0.783588] spi-nor spi0.0: en25qh64 (8192 Kbytes)
[    0.788669] 6 fixed-partitions partitions found on MTD device spi0.0
[    0.795221] OF: Bad cell count for /palmbus@10000000/spi@b00/flash@0/partitions
[    0.802723] OF: Bad cell count for /palmbus@10000000/spi@b00/flash@0/partitions